### PR TITLE
Use `runtimeOnly` to prevent depending on infra at compile phase

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,7 +58,7 @@ configure(listOf(project("presentation"))) {
         implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
         implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.3")
         testImplementation("org.springframework.security:spring-security-test")
-        implementation(project(":infrastructure"))
+        runtimeOnly(project(":infrastructure"))
         implementation(project(":application"))
         implementation(project(":domain"))
     }


### PR DESCRIPTION
こんにちは、[blog](https://blog.takehata-engineer.com/entry/realizing-an-onion-architecture-in-kotlin-and-spring-boot-with-gradle-multi-project)拝見しました。 "SpringのDIの仕様上Presentation層からInfrastructure層への依存が必要" と記載されている箇所ですが、 `runtimeOnly` を使うことで「コード上で依存させないこと」と「SpringがDI時に参照できること」を両立できると思いました。

サーバがエラー無く立ち上がるところまでは確認済みです。いちどお試しください。